### PR TITLE
Ppidd int

### DIFF
--- a/src/mpi_utils.cpp
+++ b/src/mpi_utils.cpp
@@ -126,6 +126,8 @@ extern "C" size_t dtype_size(int dtype) {
    return sizeof(FORTINT);
   case PPIDD_DOUBLE :
    return sizeof(double);
+  case PPIDD_INT :
+   return sizeof(int);
   default:
    MPIGA_Error(" dtype_size: wrong data type ",dtype);
  }
@@ -142,6 +144,9 @@ extern "C" MPI_Datatype dtype_mpi(int dtype) {
    break;
   case PPIDD_DOUBLE :
    mpi_dtype=MPI_DOUBLE;
+   break;
+  case PPIDD_INT :
+   mpi_dtype=MPI_INT;
    break;
   default:
    MPIGA_Error(" dtype_mpi: wrong data type ",dtype);

--- a/src/ppidd_defines.h
+++ b/src/ppidd_defines.h
@@ -5,4 +5,5 @@
 
 #define PPIDD_FORTINT 0
 #define PPIDD_DOUBLE  1
+#define PPIDD_INT     2
 #endif

--- a/src/ppidd_ga_mpi.cpp
+++ b/src/ppidd_ga_mpi.cpp
@@ -422,7 +422,7 @@ static int n_in_msg_mpiq=0;
         //else if (! PPIDD_Nxtval_initialised) {
         /* first call needs to be collective and will return 0*/
 	std::string name="Nxtval";
-        PPIDD_Create(&name[0],1,0,1,&PPIDD_Nxtval_handle);
+        PPIDD_Create(&name[0],1,PPIDD_FORTINT,1,&PPIDD_Nxtval_handle);
         PPIDD_Zero(PPIDD_Nxtval_handle);
         PPIDD_Nxtval_initialised=1;
         return 0;

--- a/src/ppidd_ga_mpi.cpp
+++ b/src/ppidd_ga_mpi.cpp
@@ -43,6 +43,8 @@ static int dtype_ga(int dtype) {
    break;
   case PPIDD_DOUBLE :
    return MT_C_DBL;
+  case PPIDD_INT :
+   return MT_C_INT;
   default:
    errmsg=" dtype_ga: wrong data type ";
    GA_Error(&errmsg[0],dtype);
@@ -422,7 +424,7 @@ static int n_in_msg_mpiq=0;
         //else if (! PPIDD_Nxtval_initialised) {
         /* first call needs to be collective and will return 0*/
 	std::string name="Nxtval";
-        PPIDD_Create(&name[0],1,PPIDD_FORTINT,1,&PPIDD_Nxtval_handle);
+        PPIDD_Create(&name[0],1,PPIDD_INT,1,&PPIDD_Nxtval_handle);
         PPIDD_Zero(PPIDD_Nxtval_handle);
         PPIDD_Nxtval_initialised=1;
         return 0;


### PR DESCRIPTION
This PR changes from using a `FORTINT` GA to an `int` GA for `nxtval`, i.e. the GA type used becomes unrelated to the size of Fortran integers. It all works as far as I can tell, no additional testjobs or examples are failing with this change included.

@pjknowles what do you think? One could choose instead `int64_t`, it really depends on whether you think there are any instances when `nxtval` will need this. One can always easily change this in the future if required.

The ultimate prize is a PPIDD library that does not depend upon, at build time, the size of the default Fortran integers of the application it will be linked against. This brings us a step closer.